### PR TITLE
Bump spring.version in /MavenEnterpriseApp-web

### DIFF
--- a/MavenEnterpriseApp-web/pom.xml
+++ b/MavenEnterpriseApp-web/pom.xml
@@ -26,7 +26,7 @@
 
 	<properties>
 		<!-- versions -->
-		<spring.version>5.0.2.RELEASE</spring.version>
+		<spring.version>5.2.7.RELEASE</spring.version>
 		<junit.version>4.12</junit.version>
 		<log4j.version>1.2.17</log4j.version>
 		<sonar.host.url>http://localhost:9000/</sonar.host.url>


### PR DESCRIPTION
Bumps `spring.version` from 5.0.2.RELEASE to 5.2.7.RELEASE.

Updates `spring-core` from 5.0.2.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.2.RELEASE...v5.2.7.RELEASE)

Updates `spring-web` from 5.0.2.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.2.RELEASE...v5.2.7.RELEASE)

Updates `spring-webmvc` from 5.0.2.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.2.RELEASE...v5.2.7.RELEASE)

Updates `spring-context` from 5.0.2.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.2.RELEASE...v5.2.7.RELEASE)